### PR TITLE
unsafe workaround for slow subarrays

### DIFF
--- a/src/exprlist.jl
+++ b/src/exprlist.jl
@@ -116,18 +116,22 @@ function eval_g!(out::AbstractVector, l::ExprList, xval)
     @assert length(l.valfuncs) == length(l.exprs)
 
     for i in 1:length(l.exprs)
-        out[i] = l.valfuncs[i](xval, IdentityArray(), l.exprs[i].inputvals...)
+        out[i] = l.valfuncs[i](xval, IdentityArray(), l.exprs[i].inputvals...)::eltype(out)
     end
 end
 
 # evaluate the jacobian, putting the *sparse* result into V
-function eval_jac_g!(V::AbstractVector, l::ExprList, xval)
+function eval_jac_g!(V::DenseVector, l::ExprList, xval)
     @assert length(l.gradfuncs) == length(l.exprs)
 
     idx = 1
-    for (i,x) in enumerate(l.exprs)
-        k = length(x.maptocanonical)
-        l.gradfuncs[i](xval, IdentityArray(), subarr(V, idx:(idx+k-1)), x.maptocanonical, x.inputvals...)
+    p = pointer(V)
+    for i in 1:length(l.exprs)
+        x = l.exprs[i]
+        k = length(x.maptocanonical)::Int
+        #Vsub = subarr(V, idx:(idx+k-1))
+        Vsub = VectorView(idx-1, k, p)
+        l.gradfuncs[i](xval, IdentityArray(), Vsub, x.maptocanonical, x.inputvals...)
         idx += k
     end
 
@@ -152,16 +156,35 @@ function jac_nz(l::ExprList)
     return I,J
 end
 
+# lightweight unsafe view for vectors
+# it seems that the only way to avoid triggering
+# allocations is to have only bitstype fields, so
+# we store a pointer.
+immutable VectorView{T}
+    offset::Int
+    len::Int
+    ptr::Ptr{T}
+end
+
+Base.getindex(v::VectorView,idx) = unsafe_load(v.ptr, idx+v.offset)
+Base.setindex!(v::VectorView,value,idx) = unsafe_store!(v.ptr,value,idx+v.offset)
+Base.length(v::VectorView) = v.len
+
 # evaluate the sum of the hessian of each expression at xval
 # each term weighted by lambda
-function eval_hess!(V::AbstractVector, l::ExprList, xval, lambda)
+function eval_hess!(V::DenseVector, l::ExprList, xval, lambda)
     
     idx = 1
-    for (i,x) in enumerate(l.exprs)
+    p = pointer(V)
+    for i in 1:length(l.exprs)
         nnz = length(l.hessIJ[i][1])
-        Vsub = subarr(V,idx:(idx+nnz-1))
-        l.hessfuncs[i](xval, Vsub, x)
-        scale!(Vsub, lambda[i])
+        #Vsub = subarr(V,idx:(idx+nnz-1))
+        Vsub = VectorView(idx-1,nnz,p)
+        l.hessfuncs[i](xval, Vsub, l.exprs[i])
+        for k in idx:(idx+nnz-1)
+            V[k] *= lambda[i]
+        end
+        #scale!(Vsub, lambda[i])
         idx += nnz
     end
 


### PR DESCRIPTION
Gives a 3.3x speedup on a model with 1,000,000 constraints, which means that we create 1,000,000 array views on every function call. Any allocations in this loop are bad news given the quadratic performance of the GC.
@timholy, do you know of any safer way to make a zero-allocation array view object?
@IainNZ @joehuchette
