### PR TITLE
WIP: Overwrite ^() so that is doesn't throw DomainError

### DIFF
--- a/src/revmode.jl
+++ b/src/revmode.jl
@@ -288,6 +288,7 @@ forwardvalue(x, placevalues, placeindex_in) = float(x)
 # sometimes the results aren't needed anyway,
 # because the code may compute derivatives wrt constants.
 log(x) = x <= 0 ? NaN : Base.log(x)
+^(x::Float64,y::Float64) = ccall((:pow,Base.libm_name),  Float64, (Float64,Float64), x, y)
 
 function revpass(x::ExprNode, expr_out)
     @assert isexpr(expr_out, :block)


### PR DESCRIPTION
This is meant to address this JuliaOpt/JuMP.jl#318

There is still a problem with this: this patch overwrites the general `^` function, which we don't want.

When I use the package with this patch I get this:

```
julia> using ReverseDiffSparse
Warning: Method definition ^(Float64,Float64) in module Math at math.jl:252 overwritten in module ReverseDiffSparse at C:\Users\anthoff\.julia\v0.3\ReverseDiffSparse\src\revmode.jl:291.
```

I actually don't understand why that happens for the `^` method, but not for `log`, which is overwritten in the line above it? Essentially we should have this overwrite ONLY apply for the ReverseDiff package, nothing else, i.e. this should work in the same way as the existing line above it.

@mlubin can you take a look? Thanks!
