### PR TITLE
refactor to store original expression in SymbolicOutput

### DIFF
--- a/src/export.jl
+++ b/src/export.jl
@@ -81,7 +81,7 @@ function to_flat_expr(x::SymbolicOutput)
     for i in 1:length(x.inputnames)
         push!( out.args, :( $(x.inputnames[i]) = $(x.inputvals[i]) ))
     end
-    expr = outputpass(x.tree, out)
+    expr = outputpass(genExprGraph(x.tree), out)
     fexpr = quote
         let
             $out
@@ -96,7 +96,7 @@ export to_flat_expr
 
 function genfexpr_parametric(x::SymbolicOutput)
     out = Expr(:block)
-    fval = outputpass(x.tree, out)
+    fval = outputpass(genExprGraph(x.tree), out)
     fname = gensym()
     fexpr = quote
         function $(fname)()

--- a/src/hessian.jl
+++ b/src/hessian.jl
@@ -10,7 +10,7 @@ normalize(e) = normalize(e...)
 function compute_hessian_sparsity_IJ_parametric(s::SymbolicOutput)
 
     code = quote end
-    compute_hessian_sparsity(s.tree, true, code)
+    compute_hessian_sparsity(genExprGraph(s.tree), true, code)
     # compile a function:
     fexpr = quote
         local _SPARSITY_GEN_

--- a/test/test_output.jl
+++ b/test/test_output.jl
@@ -6,6 +6,8 @@ y = placeholders(3)
 ex = @processNLExpr sin(y[1])
 @test to_flat_expr(ex) == :(sin(x[1]))
 
+@test base_expression(ex) == :(sin(y[1]))
+
 
 ex = @processNLExpr sin(y[1])^2
 @test to_flat_expr(ex) == :(sin(x[1])^2)


### PR DESCRIPTION
This should make printing easier, @IainNZ @joehuchette.
Breaks JuMP's tests because it was digging into the SymbolicOutput type.