### PR TITLE
Refactor eval_univariate to avoid depending on Lazy.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,5 @@
 julia 0.5
 Calculus
-Lazy
 DataStructures
 MathProgBase
 NaNMath 0.2.1

--- a/src/ReverseDiffSparse.jl
+++ b/src/ReverseDiffSparse.jl
@@ -3,7 +3,6 @@ module ReverseDiffSparse
 using Base.Meta
 using ForwardDiff
 import Calculus
-import Lazy
 import MathProgBase
 # Override basic math functions to return NaN instead of throwing errors.
 # This is what NLP solvers expect, and


### PR DESCRIPTION
Also switch to a binary nested if - worth checking if this part is good or bad for performance. Could make it linear, the same as `Lazy.@switch`, if this turns out to hurt. Are there benchmarks somewhere?